### PR TITLE
Patch for issue #98

### DIFF
--- a/src/fszmq/fszmq.fsproj
+++ b/src/fszmq/fszmq.fsproj
@@ -77,9 +77,9 @@
     <Compile Include="Context.fs" />
     <Compile Include="Polling.fs" />
     <Compile Include="Utilities.fs" />
+    <None Include="Scratch.fsx" />
     <None Include="paket.references" />
     <None Include="paket.template" />
-    <None Include="Scratch.fsx" />
   </ItemGroup>
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">

--- a/tests/fszmq.tests/fszmq.tests-osx.fsproj
+++ b/tests/fszmq.tests/fszmq.tests-osx.fsproj
@@ -89,6 +89,8 @@
   <Import Project="$(FSharpTargetsPath)" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <ItemGroup>
+    <Compile Include="Miscellany.fs" />
+    <Compile Include="Messages.fs" />
     <None Include="app.config" />
     <None Include="..\..\lib\zeromq\OSX\fszmq.dll.config">
       <Link>fszmq.dll.config</Link>
@@ -103,8 +105,6 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="paket.references" />
-    <Compile Include="Miscellany.fs" />
-    <Compile Include="Messages.fs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />


### PR DESCRIPTION
* src/fszmq/fszmq.fsproj: file reorder
* tests/fszmq.tests/fszmq.tests-osx.fsproj: file order

* src/fszmq/Core.fs:
  Changed Context to have reference equality based on native handle;
  Changed Context to track Sockets in a thread-safe fashion; Added
  ToString overrides (showing native handle) to Context, Socket, and
  Message types