### PR TITLE
minor house-keeping; version bump to address corrupt NuPkg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,6 +159,9 @@ $RECYCLE.BIN/
 # Exclude F# project specific directories and files
 # ===================================================
 
+# Paket stuff
+.paket/paket.exe
+
 # NuGet Packages Directory
 packages/
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+### New in 12.2.2 (2017/01/31)
+* Version bump (attempting to address NuGet.org issues)
+
 ### New in 12.2.1 (2016/07/18)
 * FIX (untracked) `Socket.getOptionWithBuffer`, `Socket.getOption` fail when reading boolean options
 

--- a/build.fsx
+++ b/build.fsx
@@ -172,9 +172,7 @@ Target "Archive" (fun _ ->
   !! "lib/zeromq/WIN/x64/libzmq.*"  |> Copy (winDir + "/x64")
   // compress
   !! (rootDir + "/**/*.*") 
-    |> Zip rootDir ("bin/fszmq-" + release.NugetVersion + ".zip")
-  // clean up
-  DeleteDir rootDir)
+    |> Zip rootDir ("bin/fszmq-" + release.NugetVersion + ".zip"))
 
 Target "NuGet" (fun _ ->
   Paket.Pack(fun p ->

--- a/src/fszmq/AssemblyInfo.fs
+++ b/src/fszmq/AssemblyInfo.fs
@@ -10,9 +10,9 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("fszmq")>]
 [<assembly: AssemblyProductAttribute("fszmq")>]
 [<assembly: AssemblyDescriptionAttribute("An MPLv2-licensed F# binding for the ZeroMQ distributed computing library.")>]
-[<assembly: AssemblyVersionAttribute("12.2.1")>]
-[<assembly: AssemblyFileVersionAttribute("12.2.1")>]
+[<assembly: AssemblyVersionAttribute("12.2.2")>]
+[<assembly: AssemblyFileVersionAttribute("12.2.2")>]
 do ()
 
 module internal AssemblyVersionInformation =
-    let [<Literal>] Version = "12.2.1"
+    let [<Literal>] Version = "12.2.2"

--- a/tests/fszmq.tests/fszmq.tests-win.fsproj
+++ b/tests/fszmq.tests/fszmq.tests-win.fsproj
@@ -103,7 +103,6 @@
   <ItemGroup>
     <Compile Include="Miscellany.fs" />
     <Compile Include="Messages.fs" />
-    <Compile Include="Termination.fs" />
     <Compile Include="SocketOptions.fs" />
     <None Include="Scratch.fsx" />
     <None Include="..\..\lib\zeromq\WIN\x86\libzmq.dll">


### PR DESCRIPTION
1. Minor house-keeping:
    + Remove `paket.exe` from repo (that's why we have a boot-strapping program)
    + Remove non-existant file from Windows project (never should've been committed in the first place)
    + Remove superfluous clean-up step when producing `.zip` archive
2. Version bump
    + The `.nupkg` for version 12.2.1 was corrupted (on http://nuget.org). The only way to fix it was to upload a new version (Nuget's rules -- not mine).
