### PR TITLE
try to fix multiple enumeration of byte array seq

### DIFF
--- a/src/fszmq/Socket.fs
+++ b/src/fszmq/Socket.fs
@@ -135,15 +135,8 @@ module Socket =
   /// If message is empty, sends a single empty frame for convenience
   [<Extension;CompiledName("SendAll")>]
   let sendAll socket message =
-    let len = Seq.length message
-    match len with 
-    | 0 -> send socket Array.empty
-    | 1 -> send socket (Seq.exactlyOne message)
-    | _ -> message
-           |> Seq.take (len - 1)
-           |> Seq.fold sendMore socket
-           |> (fun socket -> send socket (Seq.last message))
-
+    message |> Seq.iter (sendMore socket >> ignore)
+    send socket Array.empty
 (* message receiving *)
 
   /// Gets the next available frame from a socket, returning a frame option


### PR DESCRIPTION
Hello, I use Socket.sendAll in order to reuse the same buffer in a sequence but the Seq.length, last and take enumerate the seq multiple times causing some issues.

I use this implementation on a poc script and it works well.

What do you think about this ?