### PR TITLE
docs: add extras sample for push pull and router dealer

### DIFF
--- a/docs/content/extras/zmq-ha-pushpull.fsx
+++ b/docs/content/extras/zmq-ha-pushpull.fsx
@@ -1,0 +1,109 @@
+(*** do-not-eval-file ***)
+(*** hide ***)
+#I "../../../bin"
+#load "../docs.fs"
+open docs
+PATH.hijack ()
+
+(**
+A High Available Push Pull using Proxy
+====================
+
+Connects PULL socket to tcp://localhost:5572 and tcp://localhost:5574 
+
+Send Hello without loosing message with ZMQ.IMMEDIATE over a PROXY
+
+Cancel and restart p1 and p2 proxies to check the High Availibility behavior
+
+*)
+
+#r @"fszmq.dll"
+
+
+open fszmq
+open fszmq.Context
+open fszmq.Socket
+open System
+
+let decode x = System.Text.Encoding.UTF8.GetString(x)
+let encode x = System.Text.Encoding.UTF8.GetBytes(x:string)
+
+let srecv = recv >> decode
+
+type [<Struct>] Identity = Identity of string
+type [<Struct>] Port = Port of int
+type [<Struct>] Times = Times of int
+
+type [<Measure>] s
+type [<Measure>] ms
+
+type [<Struct>] ThinkTime = ThinkTime of float<s>
+let milliseconds = 1000.<ms/s>
+
+let proxy (Port inPort) (Port outPort) token = 
+    async {
+        use context = new Context ()
+        use pullC = Context.pull context
+        use pushC = Context.push context
+        (ZMQ.IMMEDIATE, 1) |> Socket.setOption pushC
+        
+        
+        inPort |> sprintf "tcp://*:%i" |> Socket.bind pullC 
+        outPort |> sprintf "tcp://*:%i" |> Socket.bind pushC
+
+        Async.Start(async {fszmq.Proxying.proxy pushC pullC None}, token)
+        do! token.WaitHandle |> Async.AwaitWaitHandle |> Async.Ignore
+    }
+
+let receive (Identity identity) ports = 
+    use context = new Context ()
+    use channel = pull context
+    ports |> List.iter (fun (Port port) -> sprintf "tcp://localhost:%i" port |> connect channel)
+    
+    let rec handle () = 
+        let msg = srecv channel
+        printfn "%O - I%s: reader receive : %s" (DateTime.Now) identity msg
+        handle ()
+    handle ()
+
+let send (ThinkTime thinktime) (Times times) ports = 
+    async { 
+        use context = new Context ()
+        use channel = push context
+        (ZMQ.IMMEDIATE, 1) |> Socket.setOption channel
+
+        ports |> List.iter (fun (Port port) -> sprintf "tcp://localhost:%i" port |> connect channel)
+
+        let send t = 
+            async {
+                sprintf "hello %i" t |> encode |> send channel
+                printfn "send(%i) finished" t
+            }
+        do! 
+            [1 .. times ] 
+            |> List.fold (fun s t -> 
+                async { 
+                    do! s
+                    if thinktime > 0.<s> then do! milliseconds * thinktime |> int |> Async.Sleep
+                    do! send t }) (async.Return ()) } 
+
+module Async = 
+    let start x = 
+        let token = new System.Threading.CancellationTokenSource ()
+        Async.Start(x token.Token, token.Token)
+        token
+
+//Proxy nodes on server A and B as P component
+let p1 = proxy (Port 5571) (Port 5572) |> Async.start
+let p2 = proxy (Port 5573) (Port 5574) |> Async.start
+
+//Receiver server C and D as R component (connected to P output)
+async { receive (Identity "1") [Port 5572; Port 5574] } |> Async.Start
+async { receive (Identity "2") [Port 5572; Port 5574] } |> Async.Start
+
+//Sender server E as S component (connected to P input)
+send (ThinkTime 0.5<s>) (Times 200) [Port 5571;Port 5573] |> Async.Start
+
+
+p1.Cancel()
+p2.Cancel()

--- a/docs/content/extras/zmq-ha-router-dealer.fsx
+++ b/docs/content/extras/zmq-ha-router-dealer.fsx
@@ -1,0 +1,137 @@
+﻿(*** do-not-eval-file ***)
+(*** hide ***)
+#I "../../../bin"
+#load "../docs.fs"
+open docs
+PATH.hijack ()
+
+(**
+A High Available Router Dealer
+====================
+
+Connects DEALER socket to tcp://localhost:6666 and tcp://localhost:6667 
+
+Send Hello without loosing message with ZMQ.IMMEDIATE
+
+Cancel and restart r1 and r2 to check the High Availibility behavior
+
+*)
+
+#r @"fszmq.dll"
+
+open fszmq
+open fszmq.Context
+open fszmq.Socket
+open System
+
+let decode x = System.Text.Encoding.UTF8.GetString(x)
+let encode x = System.Text.Encoding.UTF8.GetBytes(x:string)
+
+let srecv = recv >> decode
+
+type [<Struct>] Identity = Identity of string
+type [<Struct>] Port = Port of int
+type [<Struct>] Times = Times of int
+
+type [<Measure>] s
+type [<Measure>] ms
+
+type [<Struct>] ThinkTime = ThinkTime of float<s>
+let milliseconds = 1000.<ms/s>
+
+let client (ThinkTime thinktime) (Times times) (Identity identity) (Identity dest) ports msg = 
+    async {
+        use context = new Context ()
+        use channel = dealer context
+        (ZMQ.IMMEDIATE, 1) |> Socket.setOption channel
+        (ZMQ.IDENTITY, identity) |> setOption channel 
+
+        ports |> List.iter (fun (Port port) -> sprintf "tcp://localhost:%i" port |> connect channel)
+        do!
+            [ 1 .. times ]
+            |> List.fold (fun s t -> 
+                async {
+                    do! s
+                    if thinktime > 0.<s> then 
+                        //do printfn "%s is sleeping %i" identity t
+                        do! milliseconds * thinktime |> int |> Async.Sleep
+                    do channel <~| encode dest <<| encode (sprintf "(%i) %s" t msg)
+                    printfn "client sent %i" t }) (async.Return ())
+    }
+
+let server (Identity identity) ports = 
+    async {
+        use context = new Context()
+        use channel  = dealer context
+
+        (ZMQ.IMMEDIATE, 1) |> Socket.setOption channel
+        (ZMQ.IDENTITY, (identity:string)) |> setOption channel 
+        
+        ports |> List.iter (fun (Port port) -> sprintf "tcp://localhost:%i" port |> connect channel)
+        
+        let rec handle () = 
+            let msg = srecv channel
+            printfn "dealer %s received : %s" identity msg
+            handle ()
+        handle () }
+
+let router (Port port) (token:System.Threading.CancellationToken) = 
+    let route channel = 
+        let identity = Socket.recv channel |> decode
+        let dest = Socket.recv channel
+        let client = channel <~| dest
+        use message = new Message ()
+        Message.recv message channel
+
+        while Message.hasMore message do
+            client <~| Message.data message
+            |> ignore
+            Message.recv message channel
+        printfn "routing message from %s and router port %i" identity port
+        client <<| Message.data message
+    
+    async {
+        use context = new Context()
+        use channel  = router context
+        
+        sprintf "tcp://*:%i" port |> bind channel
+        
+        let rec handle () = 
+            route channel
+            if token.IsCancellationRequested |> not then handle ()
+            else printfn "router %i terminated" port
+        handle () }
+
+module Async = 
+    let start x = 
+        let token = new System.Threading.CancellationTokenSource ()
+        Async.Start(x token.Token, token.Token)
+        token
+
+let pacman = Identity "pacman"
+let donkey = Identity "donkey"
+let mario = Identity "mario"
+let luigi = Identity "luigi"
+
+//Router nodes on Server A and B as Component R
+let r1 = Port 6666 |> router |> Async.start
+let r2 = Port 6667 |> router |> Async.start
+
+//Services on Server B and C as Component S (connected as R)
+server pacman [Port 6666; Port 6667] |> Async.Start
+server donkey [Port 6666; Port 6667] |> Async.Start
+
+let send idt dest ports = sprintf "%O hello from %A" DateTime.UtcNow idt |> client (ThinkTime 3.<s>) (Times 20) idt dest ports
+
+//Client on Server D, E, F, G as Component C (connected as R)
+send mario pacman [Port 6666; Port 6667] |> Async.Start
+send mario donkey [Port 6666; Port 6667] |> Async.Start
+send luigi pacman [Port 6666; Port 6667] |> Async.Start
+send luigi donkey [Port 6666; Port 6667] |> Async.Start
+
+r1.Cancel()
+r2.Cancel()
+
+
+(*** hide ***)
+PATH.release ()

--- a/fszmq.sln
+++ b/fszmq.sln
@@ -1,6 +1,7 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30413.136
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".paket", ".paket", "{63297B98-5CED-492C-A5B7-A5B4F73CF142}"
 	ProjectSection(SolutionItems) = preProject
 		paket.dependencies = paket.dependencies
@@ -15,9 +16,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tools", "tools", "{83F16175
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "content", "content", "{8E6D5255-776D-4B61-85F9-73C37AA1FB9A}"
 	ProjectSection(SolutionItems) = preProject
+		docs\content\docs.fs = docs\content\docs.fs
 		docs\content\index.fsx = docs\content\index.fsx
 		docs\content\tutorial.fsx = docs\content\tutorial.fsx
-		docs\content\docs.fs = docs\content\docs.fs
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "zguide", "zguide", "{007DAB23-B6A5-4F2E-B1EA-9DF9118B2780}"
@@ -53,59 +54,49 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "project", "project", "{BF60BC93-E09B-4E5F-9D85-95A519479D54}"
 	ProjectSection(SolutionItems) = preProject
 		build.fsx = build.fsx
-		README.md = README.md
-		RELEASE_NOTES.md = RELEASE_NOTES.md
-		paket.dependencies = paket.dependencies
 		CONTRIBUTING.md = CONTRIBUTING.md
 		LICENSE.txt = LICENSE.txt
+		paket.dependencies = paket.dependencies
+		README.md = README.md
+		RELEASE_NOTES.md = RELEASE_NOTES.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{ED8079DD-2B06-4030-9F0F-DC548F98E1C4}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "compat", "compat", "{A7777B8C-3AC4-4DFC-95C0-11D74FC6115B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "fszmq.compat.cs", "tests\fszmq.compat.cs\fszmq.compat.cs.csproj", "{2D33436B-A803-4B3D-A76D-A381BC7FC429}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "fszmq.compat.cs", "tests\fszmq.compat.cs\fszmq.compat.cs.csproj", "{2D33436B-A803-4B3D-A76D-A381BC7FC429}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "perf", "perf", "{F3DD00B0-1075-472A-B0B1-F5FB67FF2B4C}"
 EndProject
-Project("{f2a71f9b-5d33-465a-a702-920d77279786}") = "fszmq.perf.inproc_lat", "tests\fszmq.perf.inproc_lat\fszmq.perf.inproc_lat.fsproj", "{F9462E0C-847A-4AAD-844F-FA5FA538B543}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "fszmq.perf.inproc_lat", "tests\fszmq.perf.inproc_lat\fszmq.perf.inproc_lat.fsproj", "{F9462E0C-847A-4AAD-844F-FA5FA538B543}"
 EndProject
-Project("{f2a71f9b-5d33-465a-a702-920d77279786}") = "fszmq.perf.inproc_thr", "tests\fszmq.perf.inproc_thr\fszmq.perf.inproc_thr.fsproj", "{267CB036-120C-4457-9193-65DAA3CB34AB}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "fszmq.perf.inproc_thr", "tests\fszmq.perf.inproc_thr\fszmq.perf.inproc_thr.fsproj", "{267CB036-120C-4457-9193-65DAA3CB34AB}"
 EndProject
-Project("{f2a71f9b-5d33-465a-a702-920d77279786}") = "fszmq.perf.local_lat", "tests\fszmq.perf.local_lat\fszmq.perf.local_lat.fsproj", "{D9B70E39-A90B-4BC0-9413-33D375F23BF7}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "fszmq.perf.local_lat", "tests\fszmq.perf.local_lat\fszmq.perf.local_lat.fsproj", "{D9B70E39-A90B-4BC0-9413-33D375F23BF7}"
 EndProject
-Project("{f2a71f9b-5d33-465a-a702-920d77279786}") = "fszmq.perf.remote_lat", "tests\fszmq.perf.remote_lat\fszmq.perf.remote_lat.fsproj", "{B53FB44D-54E6-43B5-9590-E38A48A2490D}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "fszmq.perf.remote_lat", "tests\fszmq.perf.remote_lat\fszmq.perf.remote_lat.fsproj", "{B53FB44D-54E6-43B5-9590-E38A48A2490D}"
 EndProject
-Project("{f2a71f9b-5d33-465a-a702-920d77279786}") = "fszmq.perf.local_thr", "tests\fszmq.perf.local_thr\fszmq.perf.local_thr.fsproj", "{2FB9221E-3695-429A-83A1-075DE00827A2}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "fszmq.perf.local_thr", "tests\fszmq.perf.local_thr\fszmq.perf.local_thr.fsproj", "{2FB9221E-3695-429A-83A1-075DE00827A2}"
 EndProject
-Project("{f2a71f9b-5d33-465a-a702-920d77279786}") = "fszmq.perf.remote_thr", "tests\fszmq.perf.remote_thr\fszmq.perf.remote_thr.fsproj", "{9D0E4922-695E-4036-9928-00F528A8E183}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "fszmq.perf.remote_thr", "tests\fszmq.perf.remote_thr\fszmq.perf.remote_thr.fsproj", "{9D0E4922-695E-4036-9928-00F528A8E183}"
 EndProject
-Project("{f2a71f9b-5d33-465a-a702-920d77279786}") = "fszmq", "src\fszmq\fszmq.fsproj", "{FDA50C33-B288-4E42-9141-D78BDDEF9466}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "fszmq", "src\fszmq\fszmq.fsproj", "{FDA50C33-B288-4E42-9141-D78BDDEF9466}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "fszmq.tests", "tests\fszmq.tests\fszmq.tests.fsproj", "{E6B638D2-D91B-4E89-956D-92B067F26E35}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "fszmq.tests", "tests\fszmq.tests\fszmq.tests.fsproj", "{E6B638D2-D91B-4E89-956D-92B067F26E35}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{1E521EEE-7087-4294-9F07-0ECBBF354D48}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
 		Debug|x64 = Debug|x64
-		Release|x64 = Release|x64
 		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{267CB036-120C-4457-9193-65DAA3CB34AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{267CB036-120C-4457-9193-65DAA3CB34AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{267CB036-120C-4457-9193-65DAA3CB34AB}.Debug|x64.ActiveCfg = Debug|x64
-		{267CB036-120C-4457-9193-65DAA3CB34AB}.Debug|x64.Build.0 = Debug|x64
-		{267CB036-120C-4457-9193-65DAA3CB34AB}.Debug|x86.ActiveCfg = Debug|x86
-		{267CB036-120C-4457-9193-65DAA3CB34AB}.Debug|x86.Build.0 = Debug|x86
-		{267CB036-120C-4457-9193-65DAA3CB34AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{267CB036-120C-4457-9193-65DAA3CB34AB}.Release|Any CPU.Build.0 = Release|Any CPU
-		{267CB036-120C-4457-9193-65DAA3CB34AB}.Release|x64.ActiveCfg = Release|x64
-		{267CB036-120C-4457-9193-65DAA3CB34AB}.Release|x64.Build.0 = Release|x64
-		{267CB036-120C-4457-9193-65DAA3CB34AB}.Release|x86.ActiveCfg = Release|x86
-		{267CB036-120C-4457-9193-65DAA3CB34AB}.Release|x86.Build.0 = Release|x86
 		{2D33436B-A803-4B3D-A76D-A381BC7FC429}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2D33436B-A803-4B3D-A76D-A381BC7FC429}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2D33436B-A803-4B3D-A76D-A381BC7FC429}.Debug|x64.ActiveCfg = Debug|x64
@@ -118,6 +109,54 @@ Global
 		{2D33436B-A803-4B3D-A76D-A381BC7FC429}.Release|x64.Build.0 = Release|x64
 		{2D33436B-A803-4B3D-A76D-A381BC7FC429}.Release|x86.ActiveCfg = Release|x86
 		{2D33436B-A803-4B3D-A76D-A381BC7FC429}.Release|x86.Build.0 = Release|x86
+		{F9462E0C-847A-4AAD-844F-FA5FA538B543}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F9462E0C-847A-4AAD-844F-FA5FA538B543}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F9462E0C-847A-4AAD-844F-FA5FA538B543}.Debug|x64.ActiveCfg = Debug|x64
+		{F9462E0C-847A-4AAD-844F-FA5FA538B543}.Debug|x64.Build.0 = Debug|x64
+		{F9462E0C-847A-4AAD-844F-FA5FA538B543}.Debug|x86.ActiveCfg = Debug|x86
+		{F9462E0C-847A-4AAD-844F-FA5FA538B543}.Debug|x86.Build.0 = Debug|x86
+		{F9462E0C-847A-4AAD-844F-FA5FA538B543}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F9462E0C-847A-4AAD-844F-FA5FA538B543}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F9462E0C-847A-4AAD-844F-FA5FA538B543}.Release|x64.ActiveCfg = Release|x64
+		{F9462E0C-847A-4AAD-844F-FA5FA538B543}.Release|x64.Build.0 = Release|x64
+		{F9462E0C-847A-4AAD-844F-FA5FA538B543}.Release|x86.ActiveCfg = Release|x86
+		{F9462E0C-847A-4AAD-844F-FA5FA538B543}.Release|x86.Build.0 = Release|x86
+		{267CB036-120C-4457-9193-65DAA3CB34AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{267CB036-120C-4457-9193-65DAA3CB34AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{267CB036-120C-4457-9193-65DAA3CB34AB}.Debug|x64.ActiveCfg = Debug|x64
+		{267CB036-120C-4457-9193-65DAA3CB34AB}.Debug|x64.Build.0 = Debug|x64
+		{267CB036-120C-4457-9193-65DAA3CB34AB}.Debug|x86.ActiveCfg = Debug|x86
+		{267CB036-120C-4457-9193-65DAA3CB34AB}.Debug|x86.Build.0 = Debug|x86
+		{267CB036-120C-4457-9193-65DAA3CB34AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{267CB036-120C-4457-9193-65DAA3CB34AB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{267CB036-120C-4457-9193-65DAA3CB34AB}.Release|x64.ActiveCfg = Release|x64
+		{267CB036-120C-4457-9193-65DAA3CB34AB}.Release|x64.Build.0 = Release|x64
+		{267CB036-120C-4457-9193-65DAA3CB34AB}.Release|x86.ActiveCfg = Release|x86
+		{267CB036-120C-4457-9193-65DAA3CB34AB}.Release|x86.Build.0 = Release|x86
+		{D9B70E39-A90B-4BC0-9413-33D375F23BF7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D9B70E39-A90B-4BC0-9413-33D375F23BF7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D9B70E39-A90B-4BC0-9413-33D375F23BF7}.Debug|x64.ActiveCfg = Debug|x64
+		{D9B70E39-A90B-4BC0-9413-33D375F23BF7}.Debug|x64.Build.0 = Debug|x64
+		{D9B70E39-A90B-4BC0-9413-33D375F23BF7}.Debug|x86.ActiveCfg = Debug|x86
+		{D9B70E39-A90B-4BC0-9413-33D375F23BF7}.Debug|x86.Build.0 = Debug|x86
+		{D9B70E39-A90B-4BC0-9413-33D375F23BF7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D9B70E39-A90B-4BC0-9413-33D375F23BF7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D9B70E39-A90B-4BC0-9413-33D375F23BF7}.Release|x64.ActiveCfg = Release|x64
+		{D9B70E39-A90B-4BC0-9413-33D375F23BF7}.Release|x64.Build.0 = Release|x64
+		{D9B70E39-A90B-4BC0-9413-33D375F23BF7}.Release|x86.ActiveCfg = Release|x86
+		{D9B70E39-A90B-4BC0-9413-33D375F23BF7}.Release|x86.Build.0 = Release|x86
+		{B53FB44D-54E6-43B5-9590-E38A48A2490D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B53FB44D-54E6-43B5-9590-E38A48A2490D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B53FB44D-54E6-43B5-9590-E38A48A2490D}.Debug|x64.ActiveCfg = Debug|x64
+		{B53FB44D-54E6-43B5-9590-E38A48A2490D}.Debug|x64.Build.0 = Debug|x64
+		{B53FB44D-54E6-43B5-9590-E38A48A2490D}.Debug|x86.ActiveCfg = Debug|x86
+		{B53FB44D-54E6-43B5-9590-E38A48A2490D}.Debug|x86.Build.0 = Debug|x86
+		{B53FB44D-54E6-43B5-9590-E38A48A2490D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B53FB44D-54E6-43B5-9590-E38A48A2490D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B53FB44D-54E6-43B5-9590-E38A48A2490D}.Release|x64.ActiveCfg = Release|x64
+		{B53FB44D-54E6-43B5-9590-E38A48A2490D}.Release|x64.Build.0 = Release|x64
+		{B53FB44D-54E6-43B5-9590-E38A48A2490D}.Release|x86.ActiveCfg = Release|x86
+		{B53FB44D-54E6-43B5-9590-E38A48A2490D}.Release|x86.Build.0 = Release|x86
 		{2FB9221E-3695-429A-83A1-075DE00827A2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2FB9221E-3695-429A-83A1-075DE00827A2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2FB9221E-3695-429A-83A1-075DE00827A2}.Debug|x64.ActiveCfg = Debug|x64
@@ -142,42 +181,6 @@ Global
 		{9D0E4922-695E-4036-9928-00F528A8E183}.Release|x64.Build.0 = Release|x64
 		{9D0E4922-695E-4036-9928-00F528A8E183}.Release|x86.ActiveCfg = Release|x86
 		{9D0E4922-695E-4036-9928-00F528A8E183}.Release|x86.Build.0 = Release|x86
-		{B53FB44D-54E6-43B5-9590-E38A48A2490D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{B53FB44D-54E6-43B5-9590-E38A48A2490D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B53FB44D-54E6-43B5-9590-E38A48A2490D}.Debug|x64.ActiveCfg = Debug|x64
-		{B53FB44D-54E6-43B5-9590-E38A48A2490D}.Debug|x64.Build.0 = Debug|x64
-		{B53FB44D-54E6-43B5-9590-E38A48A2490D}.Debug|x86.ActiveCfg = Debug|x86
-		{B53FB44D-54E6-43B5-9590-E38A48A2490D}.Debug|x86.Build.0 = Debug|x86
-		{B53FB44D-54E6-43B5-9590-E38A48A2490D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B53FB44D-54E6-43B5-9590-E38A48A2490D}.Release|Any CPU.Build.0 = Release|Any CPU
-		{B53FB44D-54E6-43B5-9590-E38A48A2490D}.Release|x64.ActiveCfg = Release|x64
-		{B53FB44D-54E6-43B5-9590-E38A48A2490D}.Release|x64.Build.0 = Release|x64
-		{B53FB44D-54E6-43B5-9590-E38A48A2490D}.Release|x86.ActiveCfg = Release|x86
-		{B53FB44D-54E6-43B5-9590-E38A48A2490D}.Release|x86.Build.0 = Release|x86
-		{D9B70E39-A90B-4BC0-9413-33D375F23BF7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D9B70E39-A90B-4BC0-9413-33D375F23BF7}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D9B70E39-A90B-4BC0-9413-33D375F23BF7}.Debug|x64.ActiveCfg = Debug|x64
-		{D9B70E39-A90B-4BC0-9413-33D375F23BF7}.Debug|x64.Build.0 = Debug|x64
-		{D9B70E39-A90B-4BC0-9413-33D375F23BF7}.Debug|x86.ActiveCfg = Debug|x86
-		{D9B70E39-A90B-4BC0-9413-33D375F23BF7}.Debug|x86.Build.0 = Debug|x86
-		{D9B70E39-A90B-4BC0-9413-33D375F23BF7}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D9B70E39-A90B-4BC0-9413-33D375F23BF7}.Release|Any CPU.Build.0 = Release|Any CPU
-		{D9B70E39-A90B-4BC0-9413-33D375F23BF7}.Release|x64.ActiveCfg = Release|x64
-		{D9B70E39-A90B-4BC0-9413-33D375F23BF7}.Release|x64.Build.0 = Release|x64
-		{D9B70E39-A90B-4BC0-9413-33D375F23BF7}.Release|x86.ActiveCfg = Release|x86
-		{D9B70E39-A90B-4BC0-9413-33D375F23BF7}.Release|x86.Build.0 = Release|x86
-		{F9462E0C-847A-4AAD-844F-FA5FA538B543}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F9462E0C-847A-4AAD-844F-FA5FA538B543}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F9462E0C-847A-4AAD-844F-FA5FA538B543}.Debug|x64.ActiveCfg = Debug|x64
-		{F9462E0C-847A-4AAD-844F-FA5FA538B543}.Debug|x64.Build.0 = Debug|x64
-		{F9462E0C-847A-4AAD-844F-FA5FA538B543}.Debug|x86.ActiveCfg = Debug|x86
-		{F9462E0C-847A-4AAD-844F-FA5FA538B543}.Debug|x86.Build.0 = Debug|x86
-		{F9462E0C-847A-4AAD-844F-FA5FA538B543}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F9462E0C-847A-4AAD-844F-FA5FA538B543}.Release|Any CPU.Build.0 = Release|Any CPU
-		{F9462E0C-847A-4AAD-844F-FA5FA538B543}.Release|x64.ActiveCfg = Release|x64
-		{F9462E0C-847A-4AAD-844F-FA5FA538B543}.Release|x64.Build.0 = Release|x64
-		{F9462E0C-847A-4AAD-844F-FA5FA538B543}.Release|x86.ActiveCfg = Release|x86
-		{F9462E0C-847A-4AAD-844F-FA5FA538B543}.Release|x86.Build.0 = Release|x86
 		{FDA50C33-B288-4E42-9141-D78BDDEF9466}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{FDA50C33-B288-4E42-9141-D78BDDEF9466}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FDA50C33-B288-4E42-9141-D78BDDEF9466}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -203,10 +206,13 @@ Global
 		{E6B638D2-D91B-4E89-956D-92B067F26E35}.Release|x86.ActiveCfg = Release|x86
 		{E6B638D2-D91B-4E89-956D-92B067F26E35}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{A7777B8C-3AC4-4DFC-95C0-11D74FC6115B} = {ED8079DD-2B06-4030-9F0F-DC548F98E1C4}
-		{F3DD00B0-1075-472A-B0B1-F5FB67FF2B4C} = {ED8079DD-2B06-4030-9F0F-DC548F98E1C4}
 		{2D33436B-A803-4B3D-A76D-A381BC7FC429} = {A7777B8C-3AC4-4DFC-95C0-11D74FC6115B}
+		{F3DD00B0-1075-472A-B0B1-F5FB67FF2B4C} = {ED8079DD-2B06-4030-9F0F-DC548F98E1C4}
 		{F9462E0C-847A-4AAD-844F-FA5FA538B543} = {F3DD00B0-1075-472A-B0B1-F5FB67FF2B4C}
 		{267CB036-120C-4457-9193-65DAA3CB34AB} = {F3DD00B0-1075-472A-B0B1-F5FB67FF2B4C}
 		{D9B70E39-A90B-4BC0-9413-33D375F23BF7} = {F3DD00B0-1075-472A-B0B1-F5FB67FF2B4C}
@@ -215,7 +221,7 @@ Global
 		{9D0E4922-695E-4036-9928-00F528A8E183} = {F3DD00B0-1075-472A-B0B1-F5FB67FF2B4C}
 		{E6B638D2-D91B-4E89-956D-92B067F26E35} = {ED8079DD-2B06-4030-9F0F-DC548F98E1C4}
 	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {65C6372F-1C89-466A-8ADD-855C6390883D}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
I added 2 useful examples in an extras folder.

This samples are poc script to test the infra before going to prod. This sample is used in prod for 3 years now handling thousands of msg/s and terrabytes a day.